### PR TITLE
Update canvas size only if needed

### DIFF
--- a/index.js
+++ b/index.js
@@ -358,6 +358,7 @@ function fillCircle(context, center, radius, color = "green") {
 (() => {
     const canvas = document.getElementById("game");
     const context = canvas.getContext("2d");
+    let windowWasResized = true;
 
     const game = new Game();
 
@@ -369,10 +370,11 @@ function fillCircle(context, center, radius, color = "green") {
         const dt = (timestamp - start) * 0.001;
         start = timestamp;
 
-        const width = window.innerWidth;
-        const height = window.innerHeight;
-        canvas.width = width;
-        canvas.height = height;
+        if (windowWasResized) {
+            canvas.width = window.innerWidth;
+            canvas.height = window.innerHeight;
+            windowWasResized = false;
+        }
 
         game.update(dt);
         game.render(context);
@@ -396,5 +398,9 @@ function fillCircle(context, center, radius, color = "green") {
 
     document.addEventListener('mousedown', event => {
         game.mouseDown(event);
+    });
+
+    window.addEventListener('resize', event => {
+        windowWasResized = true;
     });
 })();


### PR DESCRIPTION
I did some profiling and found that it's a little better to not update size of canvas element every frame.
I tested by launching the game in small window and doing nothing. On my machine I have 11% speed increase.

<details>
  <summary>Results of 5 seconds profiling</summary>

![Comparison](https://user-images.githubusercontent.com/4366033/107085966-f20b1280-6801-11eb-922a-a7f44ca29110.png)

</details>
