### PR TITLE
Make game partially playable on smartphones

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="viewport" content="user-scalable=no">
     <title>zzzwe</title>
     <link rel="stylesheet" href="reset.css" />
     <link rel="stylesheet" href="index.css" />

--- a/index.js
+++ b/index.js
@@ -608,6 +608,12 @@ class Game {
 
     const game = new Game(context);
 
+    // https://drafts.csswg.org/mediaqueries-4/#mf-interaction
+    // https://patrickhlauke.github.io/touch/pointer-hover-any-pointer-any-hover/
+    if (window.matchMedia("(pointer: coarse)").matches) {
+        game.tutorial.playerMoved();
+    }
+
     let start;
     function step(timestamp) {
         if (start === undefined) {
@@ -638,11 +644,11 @@ class Game {
         game.keyUp(event);
     });
 
-    document.addEventListener('mousemove', event => {
+    document.addEventListener('pointermove', event => {
         game.mouseMove(event);
     });
 
-    document.addEventListener('mousedown', event => {
+    document.addEventListener('pointerdown', event => {
         game.mouseDown(event);
     });
 

--- a/index.js
+++ b/index.js
@@ -636,6 +636,8 @@ class Game {
 
     window.requestAnimationFrame(step);
 
+    // TODO(#30): game is not playable on mobile without external keyboard
+
     document.addEventListener('keydown', event => {
         game.keyDown(event);
     });


### PR DESCRIPTION
* Disabled zoom on double tap.

* Added touch screen detection that skips WASD tutorial.

* Changed mouse event listeners to pointer events. That way there's no 100 ms lag when you tap to shoot. This lag exists to distinguish between tap and scroll gestures.
<details>

<summary>Event log that illustrates mousedown lag on touch screen</summary>

![gesturetapdown](https://user-images.githubusercontent.com/4366033/107136342-e0616200-690a-11eb-97fa-6b2a03369fd9.png)


</details>