### PR TITLE
(#7) Scale game depending on resolution

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,7 +146,7 @@ class Camera {
         const height = this.height();
 
         this.context.fillStyle = color.toRgba();
-        this.context.font = "30px LexendMega";
+        this.context.font = "69px LexendMega";
         this.context.textAlign = "center";
         this.context.fillText(text, width / 2, height / 2 + 10);
     }
@@ -236,7 +236,7 @@ class Enemy {
         this.ded = false;
         this.radius = 0.0;
     }
-    
+
     update(dt, followPos) {
         let vel = followPos
             .sub(this.pos)
@@ -245,7 +245,7 @@ class Enemy {
         this.trail.push(this.pos);
         this.pos = this.pos.add(vel);
         this.trail.update(dt);
-        
+
         if (this.radius < ENEMY_RADIUS) {
             this.radius += ENEMY_SPAWN_ANIMATION_SPEED * dt;
         } else {
@@ -629,7 +629,7 @@ class Game {
 }
 
 // Resolution at which the game scale will be 1 unit per pixel
-const DEFAULT_RESOLUTION = {w: 1920, h:1080};
+const DEFAULT_RESOLUTION = {w: 3840, h: 2160};
 
 let game = null;
 


### PR DESCRIPTION
Note that at the moment this scales the entire game, including text. Not sure if that's desired or not. I have taken the liberty to rename the `toWorld` and `toScreen` with more descriptive names. The `toScreen` method has been renamed to `worldToCamera` since now camera space and screen space are no longer identical, and the callers actually cared about camera space and not screen space.

Closes #7 

edit: now that I think about it, it think also fixes #19 (though it might introduce the opposite problem where text is too small on small screens)