### PR TITLE
(#11) Make spawn rate ramp up slower but uncap it

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,6 +160,7 @@ const ENEMY_RADIUS = PLAYER_RADIUS;
 const ENEMY_SPAWN_ANIMATION_SPEED = ENEMY_RADIUS * 8;
 const ENEMY_COLOR = Color.hex("#9e95c7");
 const ENEMY_SPAWN_COOLDOWN = 1.0;
+const ENEMY_SPAWN_GROWTH = 1.01;
 const ENEMY_SPAWN_DISTANCE = 1500.0;
 const ENEMY_DESPAWN_DISTANCE = ENEMY_SPAWN_DISTANCE * 2;
 const ENEMY_DAMAGE = PLAYER_MAX_HEALTH / 5;
@@ -543,8 +544,7 @@ class Game {
             if (this.enemySpawnCooldown <= 0.0) {
                 this.spawnEnemy();
                 this.enemySpawnCooldown = this.enemySpawnRate;
-                // TODO(#11): spawning rate ramps up too quickly
-                this.enemySpawnRate = Math.max(0.01, this.enemySpawnRate - 0.01);
+                this.enemySpawnRate /= ENEMY_SPAWN_GROWTH;
             }
         }
     }


### PR DESCRIPTION
This commit makes the spawn rate grow exponentially with a slow growth rate (1% faster for every new enemy spawn), instead of having a hyperbolic spawn rate that's capped at 100 enemies per second. Currently, the spawn rate is capped at the frame rate anyway because at most one enemy is spawned per "requestAnimationFrame".

The current value for enemy spawn growth might need to be tuned down slightly, depending on how long you expect a "life" to last, although it already feels much less like you're flooded with enemies all of a sudden. It might even be interesting to allow multiple spawns per frame at that point.

Closes #11