### PR TITLE
(#8) Pause game if tab lost focus

### DIFF
--- a/index.js
+++ b/index.js
@@ -758,4 +758,14 @@ let game = null;
     window.addEventListener('resize', event => {
         windowWasResized = true;
     });
+
+    window.addEventListener('blur', event => {
+        if (game.player.health > 0.0) {
+            game.paused = true;
+        }
+    });
+
+    window.addEventListener('focus', event => {
+        start = performance.now() - 1000 / 60;
+    });
 })();


### PR DESCRIPTION
Close #8 
Right now when tab is not visible it's not calling function passed to `requestAnimationFrame`. Which is good in my opinion. But when you return to game `dt` calculation treats all this time outside of the game as one frame.
This PR explicitly pauses game if tab lost focus. And fixes `dt` calculation.