### PR TITLE
(#30) Add multitouch controls

### DIFF
--- a/index.js
+++ b/index.js
@@ -962,7 +962,7 @@ class Game {
     mouseMove(event) {
         if (!this.paused && this.player.shooting) {
             const mousePos = new V2(event.offsetX, event.offsetY);
-            this.player.target = this.camera.screenToWorld(mousePos);
+            this.player.target = this.renderer.screenToWorld(mousePos);
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -635,7 +635,11 @@ const TutorialState = Object.freeze({
     "Finished": 2,
 });
 
-const TutorialMessages = Object.freeze([
+const TutorialMessages = window.matchMedia("(pointer: coarse)").matches ? Object.freeze([
+    "Drag left side of screen to move",
+    "Drag or tap right side of screen to shoot",
+    ""
+]) : Object.freeze([
     "WASD to move",
     "Left Mouse Click to shoot",
     ""
@@ -918,10 +922,10 @@ class Game {
         this.renderEntities(this.enemies);
 
         if (this.paused) {
-            this.renderer.fillMessage("PAUSED (SPACE to resume)", MESSAGE_COLOR);
+            this.renderer.fillMessage("PAUSED (SPACE or touch to resume)", MESSAGE_COLOR);
         } else if(this.player.health <= 0.0) {
             const accuracy = Math.ceil(100 * this.player.accuracy / Math.max(this.player.shootCount, 1.0));
-            this.renderer.fillMessage(`YOUR SCORE: ${this.score}\nACCURACY: ${accuracy}%\n(SPACE to restart)`, MESSAGE_COLOR);
+            this.renderer.fillMessage(`YOUR SCORE: ${this.score}\nACCURACY: ${accuracy}%\n(SPACE or touch to restart)`, MESSAGE_COLOR);
         } else {
             this.tutorial.render(this.renderer);
         }

--- a/index.js
+++ b/index.js
@@ -1137,4 +1137,14 @@ let game = null;
     window.addEventListener('focus', event => {
         start = performance.now() - 1000 / 60;
     });
+
+    window.addEventListener("orientationchange", (event) => {
+        const angle = Math.abs(event.target.screen.orientation.angle);
+        if (angle === 90 || angle === 270) {
+            document.body.requestFullscreen()
+                .catch(error => console.error(`${error.message}. API can only be initiated after user gesture.`));
+        } else if (document.fullscreenElement){
+            document.exitFullscreen();
+        }
+    });
 })();

--- a/index.js
+++ b/index.js
@@ -1010,7 +1010,7 @@ class Game {
         }
         this.tutorial.playerMoved();
         Array.from(event.changedTouches).forEach(touch => {
-            if (touch.clientX < this.renderer.context.canvas.width / 2) {
+            if (touch.clientX < window.innerWidth / 2) {
                 if (this.movingTouchId === undefined) {
                     this.movingTouchId = touch.identifier;
                     this.movingTouchStart = new V2(touch.clientX, touch.clientY);


### PR DESCRIPTION
Close #30 
Implemented gamepad-like controls:
Left side of the screen is responsible for player movement.
Right side of the screen controls direction of shooting.

Other changes:
* Implemented continuous shooting while mouse is down and cooldown.
* Now game can be unpaused with touch or mouse click.
* If you rotate device in landscape orientation - it will enter fullscreen mode. But it's not working if you didn't touch screen.